### PR TITLE
speed up evaluation

### DIFF
--- a/utils/segment/general.py
+++ b/utils/segment/general.py
@@ -44,7 +44,7 @@ def process_mask_upsample(proto_out, out_masks, bboxes, shape):
     """
 
     c, mh, mw = proto_out.shape  # CHW
-    masks = (out_masks.tanh() @ proto_out.view(c, -1)).sigmoid().view(-1, mh, mw)
+    masks = (out_masks.tanh() @ proto_out.float().view(c, -1)).sigmoid().view(-1, mh, mw)
     masks = F.interpolate(masks[None], shape, mode='bilinear', align_corners=False)[0]  # CHW
     masks = crop(masks.permute(1, 2, 0).contiguous(), bboxes)  # HWC
     return masks.gt_(0.5)
@@ -63,7 +63,7 @@ def process_mask(proto_out, out_masks, bboxes, shape, upsample=False):
 
     c, mh, mw = proto_out.shape  # CHW
     ih, iw = shape
-    masks = (out_masks.tanh() @ proto_out.view(c, -1)).sigmoid().view(-1, mh, mw)  # CHW
+    masks = (out_masks.tanh() @ proto_out.float().view(c, -1)).sigmoid().view(-1, mh, mw)  # CHW
 
     downsampled_bboxes = bboxes.clone()
     downsampled_bboxes[:, 0] *= mw / iw

--- a/utils/segment/plots.py
+++ b/utils/segment/plots.py
@@ -132,7 +132,8 @@ def plot_images_and_masks(images, targets, masks, paths=None, fname='images.jpg'
                 for j, box in enumerate(boxes.T.tolist()):
                     if labels or conf[j] > 0.25:  # 0.25 conf thresh
                         color = colors(classes[j])
-                        if scale < 1:
+                        mh, mw = image_masks[j].shape[:2]
+                        if mh != h or mw != w:
                             mask = image_masks[j].astype(np.uint8)
                             mask = cv2.resize(mask, (w, h))
                             mask = mask.astype(np.bool)

--- a/utils/segment/plots.py
+++ b/utils/segment/plots.py
@@ -93,8 +93,8 @@ def plot_images_and_masks(images, targets, masks, paths=None, fname='images.jpg'
         if paths:
             annotator.text((x + 5, y + 5 + h), text=Path(paths[i]).name[:40], txt_color=(220, 220, 220))  # filenames
         if len(targets) > 0:
-            j = targets[:, 0] == i
-            ti = targets[j]  # image targets
+            idx = targets[:, 0] == i
+            ti = targets[idx]  # image targets
 
             boxes = xywh2xyxy(ti[:, 2:6]).T
             classes = ti[:, 1].astype('int')
@@ -126,13 +126,13 @@ def plot_images_and_masks(images, targets, masks, paths=None, fname='images.jpg'
                     image_masks = np.repeat(image_masks, nl, axis=0)
                     image_masks = np.where(image_masks == index, 1.0, 0.0)
                 else:
-                    image_masks = masks[j]
+                    image_masks = masks[idx]
 
                 im = np.asarray(annotator.im).copy()
                 for j, box in enumerate(boxes.T.tolist()):
                     if labels or conf[j] > 0.25:  # 0.25 conf thresh
                         color = colors(classes[j])
-                        mh, mw = image_masks[j].shape[:2]
+                        mh, mw = image_masks[j].shape
                         if mh != h or mw != w:
                             mask = image_masks[j].astype(np.uint8)
                             mask = cv2.resize(mask, (w, h))


### PR DESCRIPTION
since we set mr=4 as default while training, I do the same thing to evaluation, so the evaluation is in mr=4 level which saves cuda memory and speed up. 
Also the curve of mask mAP is now closer to cocoapi. Check [https://wandb.ai/laughing/evaluation-test?workspace=user-laughing](https://wandb.ai/laughing/evaluation-test?workspace=user-laughing). 
- `base` is the old one, 24.1(dashboard) vs 26.7(cocoapi), which got a big jump.
- `optimized` is the speed up version,  26.5(dashboard) vs 26.9(cocoapi).

In my case, the speed tasks 1min(3.5mins before) and pycocotool evaluation tasks 10mins(18mins before) now.
Btw since I have different coco path, I got the cocoapi result manually which the dashboard didn't show it.
