### PR TITLE
Add support for TF export

### DIFF
--- a/models/tf.py
+++ b/models/tf.py
@@ -401,8 +401,6 @@ def parse_model(d, ch, model, imgsz):  # model_dict, input_channels(3)
         elif m is Concat:
             c2 = sum(ch[-1 if x == -1 else x + 1] for x in f)
         elif m in [Detect, Segment]:
-            import pdb;
-            pdb.set_trace()
             args.append([ch[x + 1] for x in f])
             if isinstance(args[1], int):  # number of anchors
                 args[1] = [list(range(args[1] * 2))] * len(f)

--- a/models/tf.py
+++ b/models/tf.py
@@ -344,7 +344,7 @@ class TFProto(keras.layers.Layer):
         self.cv3 = TFConv(c_, c2, w=w.cv3)
     
     def call(self, inputs):
-        return self.cv2(self.cv2(self.upsample(self.cv1(inputs))))
+        return self.cv3(self.cv2(self.upsample(self.cv1(inputs))))
 
 class TFUpsample(keras.layers.Layer):
     # TF version of torch.nn.Upsample()

--- a/models/tf.py
+++ b/models/tf.py
@@ -330,7 +330,7 @@ class TFSegment(TFDetect):
         self.proto = TFProto(ch[0], self.npr, self.nm, w=w.proto)  # protos
         self.detect = TFDetect.call
 
-    def forward(self, x):
+    def call(self, x):
         p = self.proto(x[0])
         x = self.detect(self, x)
         return (x, p) if self.training else (x[0], p) if self.export else (x[0], (x[1], p))

--- a/models/tf.py
+++ b/models/tf.py
@@ -30,7 +30,7 @@ from tensorflow import keras
 from models.common import (C3, SPP, SPPF, Bottleneck, BottleneckCSP, C3x, Concat, Conv, CrossConv, DWConv,
                            DWConvTranspose2d, Focus, autopad)
 from models.experimental import MixConv2d, attempt_load
-from models.yolo import Detect
+from models.yolo import Detect, Segment
 from utils.activations import SiLU
 from utils.general import LOGGER, make_divisible, print_args
 
@@ -319,6 +319,29 @@ class TFDetect(keras.layers.Layer):
         xv, yv = tf.meshgrid(tf.range(nx), tf.range(ny))
         return tf.cast(tf.reshape(tf.stack([xv, yv], 2), [1, 1, ny * nx, 2]), dtype=tf.float32)
 
+class TFSegment(TFDetect):
+    # YOLOv5 Segment head for segmentation models
+    def __init__(self, nc=80, anchors=(), nm=32, npr=256, ch=(), imgsz=(640, 640), w=None):
+        super().__init__(nc, anchors, ch, imgsz, w)
+        self.nm = nm  # number of masks
+        self.npr = npr  # number of protos
+        self.no = 5 + nc + self.nm  # number of outputs per anchor
+        self.m = [TFConv2d(x, self.no * self.na, 1, w=w.m[i]) for i, x in enumerate(ch)]  # output conv
+        self.proto = TFProto(ch[0], self.npr, self.nm, w=w.proto)  # protos
+        self.detect = TFDetect.call
+
+    def forward(self, x):
+        p = self.proto(x[0])
+        x = self.detect(self, x)
+        return (x, p) if self.training else (x[0], p) if self.export else (x[0], (x[1], p))
+
+class TFProto(keras.layers.Layer):
+    def __init__(self, c1, c_=256, c2=32, w=None):
+        super().__init__()
+        self.cv1 = TFConv(c1, c_, k=3, w=w.cv1)
+        self.upsample = TFUpsample(None, scale_factor=2, mode='nearest')
+        self.cv2 = TFConv(c_, c_, k=3, w=w.cv2)
+        self.cv3 = TFConv(c_, c2, w=w.cv3)
 
 class TFUpsample(keras.layers.Layer):
     # TF version of torch.nn.Upsample()
@@ -377,7 +400,9 @@ def parse_model(d, ch, model, imgsz):  # model_dict, input_channels(3)
             args = [ch[f]]
         elif m is Concat:
             c2 = sum(ch[-1 if x == -1 else x + 1] for x in f)
-        elif m is Detect:
+        elif m in [Detect, Segment]:
+            import pdb;
+            pdb.set_trace()
             args.append([ch[x + 1] for x in f])
             if isinstance(args[1], int):  # number of anchors
                 args[1] = [list(range(args[1] * 2))] * len(f)

--- a/models/tf.py
+++ b/models/tf.py
@@ -333,7 +333,7 @@ class TFSegment(TFDetect):
     def call(self, x):
         p = self.proto(x[0])
         x = self.detect(self, x)
-        return (x, p) if self.training else (x[0], p) if self.export else (x[0], (x[1], p))
+        return (x, p) if self.training else ((x[0], p),)
 
 class TFProto(keras.layers.Layer):
     def __init__(self, c1, c_=256, c2=32, w=None):
@@ -407,6 +407,8 @@ def parse_model(d, ch, model, imgsz):  # model_dict, input_channels(3)
             args.append([ch[x + 1] for x in f])
             if isinstance(args[1], int):  # number of anchors
                 args[1] = [list(range(args[1] * 2))] * len(f)
+            if m is Segment:
+                args[3] = make_divisible(args[3] * gw, 8)
             args.append(imgsz)
         else:
             c2 = ch[f]

--- a/models/tf.py
+++ b/models/tf.py
@@ -342,6 +342,9 @@ class TFProto(keras.layers.Layer):
         self.upsample = TFUpsample(None, scale_factor=2, mode='nearest')
         self.cv2 = TFConv(c_, c_, k=3, w=w.cv2)
         self.cv3 = TFConv(c_, c2, w=w.cv3)
+    
+    def call(self, inputs):
+        return self.cv2(self.cv2(self.upsample(self.cv1(inputs))))
 
 class TFUpsample(keras.layers.Layer):
     # TF version of torch.nn.Upsample()


### PR DESCRIPTION
Usage:
```
python export.py --weights yolov5s-seg.pt --include tflite
```
Output
![Screenshot from 2022-08-30 13-20-58](https://user-images.githubusercontent.com/15766192/187381789-11dfa02b-7eb2-4b15-8ab1-2cd7d188bf57.png)

We'll need to wait for the official models to complete training before we can run benchmark on exported model