### PR TITLE
update Annotator.masks()

### DIFF
--- a/segment/predict.py
+++ b/segment/predict.py
@@ -160,7 +160,7 @@ def run(
                 # Mask plotting
                 import time
                 tms = time.time()
-                annotator.masks(masks, colors=[colors(x, True) for x in det[:, 5]], img_gpu=im[i], retina_masks=retina_masks)
+                annotator.masks(masks, colors=[colors(x, True) for x in det[:, 5]], img_gpu=im[i] if retina_masks else None)
                 tme = time.time()
                 print("plot mask:", tme - tms)
                 # im_masks = plot_masks(im[i], masks, colors=[colors(x, True) for x in det[:, 5]])  # shape(imh,imw,3)

--- a/segment/predict.py
+++ b/segment/predict.py
@@ -144,7 +144,7 @@ def run(
             s += '%gx%g ' % im.shape[2:]  # print string
             gn = torch.tensor(im0.shape)[[1, 0, 1, 0]]  # normalization gain whwh
             imc = im0.copy() if save_crop else im0  # for save_crop
-            annotator = Annotator(im0, line_width=line_thickness, example=str(names), pil=True)
+            annotator = Annotator(im0, line_width=line_thickness, example=str(names))
             if len(det):
                 masks = process_mask(proto[i], det[:, 6:], det[:, :4], im.shape[2:], upsample=True)  # HWC
 

--- a/segment/predict.py
+++ b/segment/predict.py
@@ -43,8 +43,7 @@ from utils.dataloaders import IMG_FORMATS, VID_FORMATS, LoadImages, LoadStreams
 from utils.general import (LOGGER, Profile, check_file, check_img_size, check_imshow, check_requirements, colorstr, cv2,
                            increment_path, non_max_suppression, print_args, scale_coords, strip_optimizer, xyxy2xywh)
 from utils.plots import Annotator, colors, save_one_box
-from utils.segment.general import process_mask, scale_image
-from utils.segment.plots import plot_masks
+from utils.segment.general import process_mask
 from utils.torch_utils import select_device, smart_inference_mode
 
 
@@ -158,13 +157,7 @@ def run(
                     s += f"{n} {names[int(c)]}{'s' * (n > 1)}, "  # add to string
 
                 # Mask plotting
-                import time
-                tms = time.time()
-                annotator.masks(masks, colors=[colors(x, True) for x in det[:, 5]], img_gpu=im[i] if retina_masks else None)
-                tme = time.time()
-                print("plot mask:", tme - tms)
-                # im_masks = plot_masks(im[i], masks, colors=[colors(x, True) for x in det[:, 5]])  # shape(imh,imw,3)
-                # annotator.im = scale_image(im.shape[2:], im_masks, im0.shape)  # scale to original h, w
+                annotator.masks(masks, colors=[colors(x, True) for x in det[:, 5]], img_gpu=None if retina_masks else im[i])
 
                 # Write results
                 for *xyxy, conf, cls in reversed(det[:, :6]):
@@ -226,8 +219,8 @@ def run(
 
 def parse_opt():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--weights', nargs='+', type=str, default='../weights/yolov5n-seg.pt', help='model path(s)')
-    parser.add_argument('--source', type=str, default='/home/laughing/Downloads/MOT17-03-FRCNN-raw.mp4', help='file/dir/URL/glob, 0 for webcam')
+    parser.add_argument('--weights', nargs='+', type=str, default=ROOT / 'yolov5s-seg.pt', help='model path(s)')
+    parser.add_argument('--source', type=str, default=ROOT / 'data/images', help='file/dir/URL/glob, 0 for webcam')
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='(optional) dataset.yaml path')
     parser.add_argument('--imgsz', '--img', '--img-size', nargs='+', type=int, default=[640], help='inference size h,w')
     parser.add_argument('--conf-thres', type=float, default=0.25, help='confidence threshold')
@@ -253,7 +246,7 @@ def parse_opt():
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--dnn', action='store_true', help='use OpenCV DNN for ONNX inference')
     parser.add_argument('--vid-stride', type=int, default=1, help='video frame-rate stride')
-    parser.add_argument('--retina-masks', default=True, action='store_true', help='whether to plot masks in native resolution')
+    parser.add_argument('--retina-masks', action='store_true', help='whether to plot masks in native resolution')
     opt = parser.parse_args()
     opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand
     print_args(vars(opt))

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -131,9 +131,10 @@ class Annotator:
                 return
             if isinstance(masks, torch.Tensor):
                 masks = torch.as_tensor(masks, dtype=torch.uint8)
+                masks = masks.permute(1, 2, 0).contiguous()
                 masks = masks.cpu().numpy()
-            masks = np.ascontiguousarray(masks.transpose(1, 2, 0))
-            masks = scale_image(masks.shape[1:], masks, self.im.shape)
+            # masks = np.ascontiguousarray(masks.transpose(1, 2, 0))
+            masks = scale_image(masks.shape[:2], masks, self.im.shape)
             masks = np.asarray(masks, dtype=np.float32)
             colors = np.asarray(colors, dtype=np.float32)  # shape(n,3)
             s = masks.sum(2, keepdims=True).clip(0, 1)   # add all masks together

--- a/utils/segment/plots.py
+++ b/utils/segment/plots.py
@@ -13,33 +13,6 @@ from ..general import xywh2xyxy
 from ..plots import Annotator, colors
 
 
-def plot_masks(im, masks, colors, alpha=0.5):
-    """
-    Args:
-        im (tensor): img is in cuda, shape: [3, h, w], range: [0, 1]
-        masks (tensor): predicted masks on cuda, shape: [n, h, w]
-        colors (List[List[Int]]): colors for predicted masks, [[r, g, b] * n]
-    Return:
-        ndarray: img after draw masks, shape: [h, w, 3]
-
-    """
-    if len(masks) == 0:
-        return im.permute(1, 2, 0).contiguous().cpu().numpy() * 255
-
-    colors = torch.tensor(colors, device=im.device).float() / 255.0
-    colors = colors[:, None, None]  # shape(n,1,1,3)
-    masks = masks.unsqueeze(3)  # shape(n,h,w,1)
-    masks_color = masks * (colors * alpha)  # shape(n,h,w,3)
-
-    inv_alph_masks = (1 - masks * alpha).cumprod(0)  # shape(n,h,w,1)
-    mcs = (masks_color * inv_alph_masks).sum(0) * 2  # mask color summand shape(n,h,w,3)
-
-    im = im.flip(dims=[0])  # flip channel
-    im = im.permute(1, 2, 0).contiguous()  # shape(h,w,3)
-    im = im * inv_alph_masks[-1] + mcs
-    return (im * 255).byte().cpu().numpy()
-
-
 @threaded
 def plot_images_and_masks(images, targets, masks, paths=None, fname='images.jpg', names=None):
     # Plot image grid with labels
@@ -119,7 +92,9 @@ def plot_images_and_masks(images, targets, masks, paths=None, fname='images.jpg'
                     image_masks = masks[idx]
 
                 im = np.asarray(annotator.im).copy()
-                for j, box in enumerate(boxes.T.tolist()):
+                resized_masks = []
+                masks_colors = []
+                for j in range(len(boxes)):
                     if labels or conf[j] > 0.25:  # 0.25 conf thresh
                         color = colors(classes[j])
                         mh, mw = image_masks[j].shape
@@ -129,9 +104,23 @@ def plot_images_and_masks(images, targets, masks, paths=None, fname='images.jpg'
                             mask = mask.astype(np.bool)
                         else:
                             mask = image_masks[j].astype(np.bool)
-                        with contextlib.suppress(Exception):
-                            im[y:y + h, x:x + w, :][mask] = im[y:y + h, x:x + w, :][mask] * 0.4 + np.array(color) * 0.6
-                annotator.fromarray(im)
+                        resized_masks.append(mask)
+                        masks_colors.append(color)
+                annotator.masks(resized_masks, colors, images[0], retina_masks=True)
+                #
+                # for j, box in enumerate(boxes.T.tolist()):
+                #     if labels or conf[j] > 0.25:  # 0.25 conf thresh
+                #         color = colors(classes[j])
+                #         mh, mw = image_masks[j].shape
+                #         if mh != h or mw != w:
+                #             mask = image_masks[j].astype(np.uint8)
+                #             mask = cv2.resize(mask, (w, h))
+                #             mask = mask.astype(np.bool)
+                #         else:
+                #             mask = image_masks[j].astype(np.bool)
+                #         with contextlib.suppress(Exception):
+                #             im[y:y + h, x:x + w, :][mask] = im[y:y + h, x:x + w, :][mask] * 0.4 + np.array(color) * 0.6
+                # annotator.fromarray(im)
     annotator.im.save(fname)  # save
 
 

--- a/utils/segment/plots.py
+++ b/utils/segment/plots.py
@@ -92,34 +92,19 @@ def plot_images_and_masks(images, targets, masks, paths=None, fname='images.jpg'
                     image_masks = masks[idx]
 
                 im = np.asarray(annotator.im).copy()
-                resized_masks = []
-                masks_colors = []
-                for j in range(len(boxes.T)):
+                for j, box in enumerate(boxes.T.tolist()):
                     if labels or conf[j] > 0.25:  # 0.25 conf thresh
-                        color = np.array(colors(classes[j]))
+                        color = colors(classes[j])
                         mh, mw = image_masks[j].shape
-                        mask = image_masks[j].astype(np.uint8)
                         if mh != h or mw != w:
+                            mask = image_masks[j].astype(np.uint8)
                             mask = cv2.resize(mask, (w, h))
-                        resized_masks.append(mask)
-                        masks_colors.append(color)
-                if len(resized_masks):
-                    resized_masks = np.stack(resized_masks, axis=0)
-                    annotator.masks(resized_masks, masks_colors)
-
-                # for j, box in enumerate(boxes.T.tolist()):
-                #     if labels or conf[j] > 0.25:  # 0.25 conf thresh
-                #         color = colors(classes[j])
-                #         mh, mw = image_masks[j].shape
-                #         if mh != h or mw != w:
-                #             mask = image_masks[j].astype(np.uint8)
-                #             mask = cv2.resize(mask, (w, h))
-                #             mask = mask.astype(np.bool)
-                #         else:
-                #             mask = image_masks[j].astype(np.bool)
-                #         with contextlib.suppress(Exception):
-                #             im[y:y + h, x:x + w, :][mask] = im[y:y + h, x:x + w, :][mask] * 0.4 + np.array(color) * 0.6
-                # annotator.fromarray(im)
+                            mask = mask.astype(np.bool)
+                        else:
+                            mask = image_masks[j].astype(np.bool)
+                        with contextlib.suppress(Exception):
+                            im[y:y + h, x:x + w, :][mask] = im[y:y + h, x:x + w, :][mask] * 0.4 + np.array(color) * 0.6
+                annotator.fromarray(im)
     annotator.im.save(fname)  # save
 
 

--- a/utils/segment/plots.py
+++ b/utils/segment/plots.py
@@ -94,20 +94,19 @@ def plot_images_and_masks(images, targets, masks, paths=None, fname='images.jpg'
                 im = np.asarray(annotator.im).copy()
                 resized_masks = []
                 masks_colors = []
-                for j in range(len(boxes)):
+                for j in range(len(boxes.T)):
                     if labels or conf[j] > 0.25:  # 0.25 conf thresh
-                        color = colors(classes[j])
+                        color = np.array(colors(classes[j]))
                         mh, mw = image_masks[j].shape
+                        mask = image_masks[j].astype(np.uint8)
                         if mh != h or mw != w:
-                            mask = image_masks[j].astype(np.uint8)
                             mask = cv2.resize(mask, (w, h))
-                            mask = mask.astype(np.bool)
-                        else:
-                            mask = image_masks[j].astype(np.bool)
                         resized_masks.append(mask)
                         masks_colors.append(color)
-                annotator.masks(resized_masks, colors, images[0], retina_masks=True)
-                #
+                if len(resized_masks):
+                    resized_masks = np.stack(resized_masks, axis=0)
+                    annotator.masks(resized_masks, masks_colors)
+
                 # for j, box in enumerate(boxes.T.tolist()):
                 #     if labels or conf[j] > 0.25:  # 0.25 conf thresh
                 #         color = colors(classes[j])


### PR DESCRIPTION
- Annotator.masks() supports both gpu plotting(inference size) and cpu plotting(native size) now, also support both opencv and PIL.
- add a new argparse sign `--retine-masks` to use cpu plotting.
- add an additional arg `img_gpu` in Annotator.masks() and keep the initialization of `im0`.

I was trying to update the plot in val with Annotator.masks(), but it'll make a lot changes. Since the image in val is the big one composed with many small images, it's not easy to plot its masks as once. So I just keep it as before.
